### PR TITLE
feat(autoqa): implementa ações e aprovações da fase 12.3.4

### DIFF
--- a/src/app/features/auto-qa-bmad/components/action-bar/action-bar.component.html
+++ b/src/app/features/auto-qa-bmad/components/action-bar/action-bar.component.html
@@ -2,13 +2,20 @@
   <div class="action-bar" role="group" aria-label="Ações disponíveis para esta execução">
     @for (action of availableActions(); track action) {
       <div class="action-bar__entry">
-        <button type="button" class="action-bar__item" disabled>
+        <button
+          type="button"
+          class="action-bar__item"
+          [disabled]="isDisabled(action)"
+          (click)="onClick(action)"
+        >
           {{ labelFor(action) }}
         </button>
         @if (pendingAction() === action) {
           <aqb-loading />
         }
-        <span class="action-bar__hint">Disponível em uma próxima etapa.</span>
+        @if (!isFunctional(action)) {
+          <span class="action-bar__hint">Disponível em uma próxima etapa.</span>
+        }
       </div>
     }
   </div>

--- a/src/app/features/auto-qa-bmad/components/action-bar/action-bar.component.scss
+++ b/src/app/features/auto-qa-bmad/components/action-bar/action-bar.component.scss
@@ -14,11 +14,24 @@
     font-family: var(--aq-font-family);
     font-size: var(--aq-font-size-sm);
     border-radius: var(--aq-radius-md);
-    border: var(--aq-border-width) solid var(--aq-border);
-    background: var(--aq-panel);
-    color: var(--aq-text-muted);
+    border: var(--aq-border-width) solid var(--aq-primary);
+    background: transparent;
+    color: var(--aq-primary);
     padding: var(--aq-space-2) var(--aq-space-4);
-    cursor: not-allowed;
+    cursor: pointer;
+    transition: background var(--aq-transition-fast), opacity var(--aq-transition-fast);
+
+    &:hover:not(:disabled) {
+      background: var(--aq-primary);
+      color: #ffffff;
+    }
+
+    &:disabled {
+      border-color: var(--aq-border);
+      background: var(--aq-panel);
+      color: var(--aq-text-muted);
+      cursor: not-allowed;
+    }
   }
 
   &__hint {

--- a/src/app/features/auto-qa-bmad/components/action-bar/action-bar.component.spec.ts
+++ b/src/app/features/auto-qa-bmad/components/action-bar/action-bar.component.spec.ts
@@ -35,13 +35,54 @@ describe('ActionBarComponent', () => {
     expect(buttons().length).toBe(1);
   });
 
-  it('toda ação vem desabilitada nesta fase, com a mensagem "Disponível em uma próxima etapa."', () => {
-    fixture.componentRef.setInput('availableActions', ['GENERATE']);
+  it('ações ainda não suportadas (ex.: VIEW_LOGS) permanecem desabilitadas com o aviso', () => {
+    fixture.componentRef.setInput('availableActions', ['VIEW_LOGS']);
     fixture.detectChanges();
 
     const item = buttons()[0];
     expect(item.disabled).toBeTrue();
     expect(fixture.nativeElement.textContent).toContain('Disponível em uma próxima etapa.');
+  });
+
+  it('ações funcionais (START/CONTINUE/GENERATE/CANCEL/APPROVE_FILE_UPDATE/APPROVE_EXECUTION) ficam habilitadas, sem o aviso', () => {
+    fixture.componentRef.setInput('availableActions', [
+      'START',
+      'CONTINUE',
+      'GENERATE',
+      'CANCEL',
+      'APPROVE_FILE_UPDATE',
+      'APPROVE_EXECUTION',
+    ]);
+    fixture.detectChanges();
+
+    for (const item of buttons()) {
+      expect(item.disabled).toBeFalse();
+    }
+    expect(fixture.nativeElement.textContent).not.toContain('Disponível em uma próxima etapa.');
+  });
+
+  it('emite actionTriggered ao clicar em uma ação funcional', () => {
+    fixture.componentRef.setInput('availableActions', ['START']);
+    fixture.detectChanges();
+
+    let emitted: string | undefined;
+    fixture.componentInstance.actionTriggered.subscribe((action) => (emitted = action));
+
+    buttons()[0].click();
+
+    expect(emitted).toBe('START');
+  });
+
+  it('não emite actionTriggered ao clicar em uma ação ainda não suportada', () => {
+    fixture.componentRef.setInput('availableActions', ['VIEW_LOGS']);
+    fixture.detectChanges();
+
+    let emitted = false;
+    fixture.componentInstance.actionTriggered.subscribe(() => (emitted = true));
+
+    buttons()[0].click();
+
+    expect(emitted).toBeFalse();
   });
 
   it('mostra indicador de carregamento no botão correspondente a pendingAction', () => {
@@ -50,5 +91,15 @@ describe('ActionBarComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('[role="status"]')).not.toBeNull();
+  });
+
+  it('desabilita todos os botões (mesmo funcionais) enquanto qualquer ação estiver pendente', () => {
+    fixture.componentRef.setInput('availableActions', ['START', 'CANCEL']);
+    fixture.componentRef.setInput('pendingAction', 'START');
+    fixture.detectChanges();
+
+    for (const item of buttons()) {
+      expect(item.disabled).toBeTrue();
+    }
   });
 });

--- a/src/app/features/auto-qa-bmad/components/action-bar/action-bar.component.ts
+++ b/src/app/features/auto-qa-bmad/components/action-bar/action-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { AqbLoadingComponent } from '../../shared/ui/loading/aqb-loading.component';
 import { AutoQaAvailableAction } from '../../models/auto-qa-enums.model';
 
@@ -20,10 +20,24 @@ const ACTION_LABELS: Record<AutoQaAvailableAction, string> = {
 };
 
 /**
- * Só renderização. `availableActions` vem exatamente como o backend
- * devolveu — nunca reordenado, filtrado ou inventado. Nesta fase (12.3.2)
- * nenhuma ação é operacional ainda: todo botão nasce desabilitado, com o
- * aviso "Disponível em uma próxima etapa.".
+ * Ações que já têm despacho real no state service a partir da Fase 12.3.4.
+ * APPLY/EXECUTE continuam fora (ainda não há Apply/Execute reais) — assim
+ * como RETRY e as ações de visualização (Preview/Diff/Logs/Learning).
+ */
+const FUNCTIONAL_ACTIONS: ReadonlySet<AutoQaAvailableAction> = new Set([
+  'START',
+  'CONTINUE',
+  'GENERATE',
+  'CANCEL',
+  'APPROVE_FILE_UPDATE',
+  'APPROVE_EXECUTION',
+]);
+
+/**
+ * Só renderização e emissão de intenção — nunca decide se uma ação é
+ * permitida (isso já veio pronto em `availableActions`) e nunca chama
+ * service/HttpClient diretamente. `availableActions` é exibida exatamente
+ * como o backend devolveu — nunca reordenada, filtrada ou inventada.
  */
 @Component({
   selector: 'app-action-bar',
@@ -37,7 +51,24 @@ export class ActionBarComponent {
   readonly availableActions = input<AutoQaAvailableAction[]>([]);
   readonly pendingAction = input<AutoQaAvailableAction | null>(null);
 
+  readonly actionTriggered = output<AutoQaAvailableAction>();
+
   protected labelFor(action: AutoQaAvailableAction): string {
     return ACTION_LABELS[action];
+  }
+
+  protected isFunctional(action: AutoQaAvailableAction): boolean {
+    return FUNCTIONAL_ACTIONS.has(action);
+  }
+
+  protected isDisabled(action: AutoQaAvailableAction): boolean {
+    return !this.isFunctional(action) || this.pendingAction() !== null;
+  }
+
+  onClick(action: AutoQaAvailableAction): void {
+    if (this.isDisabled(action)) {
+      return;
+    }
+    this.actionTriggered.emit(action);
   }
 }

--- a/src/app/features/auto-qa-bmad/components/apply-approval-panel/apply-approval-panel.component.html
+++ b/src/app/features/auto-qa-bmad/components/apply-approval-panel/apply-approval-panel.component.html
@@ -1,0 +1,38 @@
+<aqb-panel title="Aprovar aplicação de arquivos" class="apply-approval-panel">
+  <aqb-input
+    label="Aprovado por"
+    [value]="approvedBy()"
+    placeholder="Seu nome"
+    (valueChange)="onApprovedByChange($event)"
+  />
+
+  <fieldset class="apply-approval-panel__fieldset">
+    <legend>Operações autorizadas</legend>
+    @for (operation of operations; track operation) {
+      <label class="apply-approval-panel__checkbox">
+        <input
+          type="checkbox"
+          [value]="operation"
+          (change)="toggleOperation(operation, $any($event.target).checked)"
+        />
+        {{ operation }}
+      </label>
+    }
+  </fieldset>
+
+  <label class="apply-approval-panel__checkbox">
+    <input type="checkbox" name="allowFileUpdate" (change)="allowFileUpdate.set($any($event.target).checked)" />
+    Permitir atualização de arquivos existentes
+  </label>
+
+  <label class="apply-approval-panel__checkbox">
+    <input type="checkbox" name="allowWarnings" (change)="allowWarnings.set($any($event.target).checked)" />
+    Permitir aplicar mesmo havendo avisos
+  </label>
+
+  <span class="apply-approval-panel__submit">
+    <aqb-button type="button" variant="primary" [loading]="submitting()" [disabled]="!canSubmit() || submitting()" (clicked)="onSubmit()">
+      Aprovar aplicação
+    </aqb-button>
+  </span>
+</aqb-panel>

--- a/src/app/features/auto-qa-bmad/components/apply-approval-panel/apply-approval-panel.component.scss
+++ b/src/app/features/auto-qa-bmad/components/apply-approval-panel/apply-approval-panel.component.scss
@@ -1,0 +1,30 @@
+.apply-approval-panel {
+  display: block;
+
+  &__fieldset {
+    border: none;
+    padding: 0;
+    margin: var(--aq-space-3) 0;
+
+    legend {
+      font-size: var(--aq-font-size-xs);
+      color: var(--aq-text-muted);
+      margin-bottom: var(--aq-space-1);
+    }
+  }
+
+  &__checkbox {
+    display: flex;
+    align-items: center;
+    gap: var(--aq-space-2);
+    font-family: var(--aq-font-family);
+    font-size: var(--aq-font-size-sm);
+    color: var(--aq-text-secondary);
+    margin-bottom: var(--aq-space-1);
+  }
+
+  &__submit {
+    display: inline-block;
+    margin-top: var(--aq-space-3);
+  }
+}

--- a/src/app/features/auto-qa-bmad/components/apply-approval-panel/apply-approval-panel.component.spec.ts
+++ b/src/app/features/auto-qa-bmad/components/apply-approval-panel/apply-approval-panel.component.spec.ts
@@ -1,0 +1,76 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ApplyApprovalPanelComponent } from './apply-approval-panel.component';
+import { AutoQaApplyApprovalRequest } from '../../models/auto-qa-execution.model';
+
+describe('ApplyApprovalPanelComponent', () => {
+  let fixture: ComponentFixture<ApplyApprovalPanelComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [ApplyApprovalPanelComponent] });
+    fixture = TestBed.createComponent(ApplyApprovalPanelComponent);
+    fixture.detectChanges();
+  });
+
+  function checkbox(value: string): HTMLInputElement {
+    return fixture.nativeElement.querySelector(`input[type="checkbox"][value="${value}"]`);
+  }
+
+  function namedCheckbox(name: string): HTMLInputElement {
+    return fixture.nativeElement.querySelector(`input[type="checkbox"][name="${name}"]`);
+  }
+
+  function approvedByField(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('.aqb-input__field');
+  }
+
+  function submitButton(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('.apply-approval-panel__submit button');
+  }
+
+  it('renderiza approvedBy e as 4 operações autorizáveis (CREATE/UPDATE/REUSE/NONE)', () => {
+    expect(approvedByField()).not.toBeNull();
+    for (const op of ['CREATE', 'UPDATE', 'REUSE', 'NONE']) {
+      expect(checkbox(op)).not.toBeNull();
+    }
+  });
+
+  it('desabilita o envio quando approvedBy está vazio ou nenhuma operação foi selecionada', () => {
+    expect(submitButton().disabled).toBeTrue();
+
+    approvedByField().value = 'jean';
+    approvedByField().dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(submitButton().disabled).toBeTrue(); // ainda sem operação selecionada
+  });
+
+  it('emite approved com o payload correto quando válido', () => {
+    approvedByField().value = '  jean  ';
+    approvedByField().dispatchEvent(new Event('input'));
+
+    checkbox('CREATE').checked = true;
+    checkbox('CREATE').dispatchEvent(new Event('change'));
+
+    namedCheckbox('allowFileUpdate').checked = true;
+    namedCheckbox('allowFileUpdate').dispatchEvent(new Event('change'));
+
+    fixture.detectChanges();
+
+    let emitted: AutoQaApplyApprovalRequest | undefined;
+    fixture.componentInstance.approved.subscribe((v) => (emitted = v));
+
+    submitButton().click();
+
+    expect(emitted).toEqual({
+      approvedBy: 'jean',
+      authorizedOperations: ['CREATE'],
+      allowFileUpdate: true,
+      allowWarnings: false,
+    });
+  });
+
+  it('desabilita o envio enquanto submitting é verdadeiro', () => {
+    fixture.componentRef.setInput('submitting', true);
+    fixture.detectChanges();
+    expect(submitButton().disabled).toBeTrue();
+  });
+});

--- a/src/app/features/auto-qa-bmad/components/apply-approval-panel/apply-approval-panel.component.ts
+++ b/src/app/features/auto-qa-bmad/components/apply-approval-panel/apply-approval-panel.component.ts
@@ -1,0 +1,63 @@
+import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
+import { AqbPanelComponent } from '../../shared/ui/panel/aqb-panel.component';
+import { AqbInputComponent } from '../../shared/ui/input/aqb-input.component';
+import { AqbButtonComponent } from '../../shared/ui/button/aqb-button.component';
+import { ApplyOperation, AutoQaApplyApprovalRequest } from '../../models/auto-qa-execution.model';
+
+const OPERATIONS: ApplyOperation[] = ['CREATE', 'UPDATE', 'REUSE', 'NONE'];
+
+/**
+ * Aprovação de aplicação de arquivos. As operações oferecidas são o
+ * vocabulário estático real de ApplyOperation (backend) — a curadoria de
+ * qual autorizar é do usuário, o painel não inventa nem infere quais
+ * operações valem para esta execução (o DTO não traz essa informação).
+ */
+@Component({
+  selector: 'app-apply-approval-panel',
+  standalone: true,
+  imports: [AqbPanelComponent, AqbInputComponent, AqbButtonComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './apply-approval-panel.component.html',
+  styleUrl: './apply-approval-panel.component.scss',
+})
+export class ApplyApprovalPanelComponent {
+  readonly submitting = input(false);
+  readonly approved = output<AutoQaApplyApprovalRequest>();
+
+  protected readonly operations = OPERATIONS;
+
+  protected readonly approvedBy = signal('');
+  protected readonly selectedOperations = signal<ReadonlySet<ApplyOperation>>(new Set());
+  protected readonly allowFileUpdate = signal(false);
+  protected readonly allowWarnings = signal(false);
+
+  protected readonly canSubmit = computed(
+    () => this.approvedBy().trim().length > 0 && this.selectedOperations().size > 0
+  );
+
+  onApprovedByChange(value: string): void {
+    this.approvedBy.set(value);
+  }
+
+  toggleOperation(operation: ApplyOperation, checked: boolean): void {
+    const next = new Set(this.selectedOperations());
+    if (checked) {
+      next.add(operation);
+    } else {
+      next.delete(operation);
+    }
+    this.selectedOperations.set(next);
+  }
+
+  onSubmit(): void {
+    if (!this.canSubmit() || this.submitting()) {
+      return;
+    }
+    this.approved.emit({
+      approvedBy: this.approvedBy().trim(),
+      authorizedOperations: Array.from(this.selectedOperations()),
+      allowFileUpdate: this.allowFileUpdate(),
+      allowWarnings: this.allowWarnings(),
+    });
+  }
+}

--- a/src/app/features/auto-qa-bmad/components/cancel-confirm-modal/cancel-confirm-modal.component.html
+++ b/src/app/features/auto-qa-bmad/components/cancel-confirm-modal/cancel-confirm-modal.component.html
@@ -1,0 +1,23 @@
+<aqb-modal [open]="open()" title="Cancelar execução" (closed)="onDismiss()">
+  <p class="cancel-confirm-modal__warning">
+    Esta ação vai cancelar a execução. Ela não poderá continuar depois disso.
+  </p>
+
+  <aqb-textarea
+    label="Motivo (opcional)"
+    [value]="reason()"
+    placeholder="Descreva o motivo do cancelamento, se quiser..."
+    (valueChange)="onReasonChange($event)"
+  />
+
+  <div class="cancel-confirm-modal__actions">
+    <span class="cancel-confirm-modal__dismiss">
+      <aqb-button variant="secondary" (clicked)="onDismiss()">Voltar</aqb-button>
+    </span>
+    <span class="cancel-confirm-modal__confirm">
+      <aqb-button variant="danger" [loading]="submitting()" [disabled]="submitting()" (clicked)="onConfirm()">
+        Confirmar cancelamento
+      </aqb-button>
+    </span>
+  </div>
+</aqb-modal>

--- a/src/app/features/auto-qa-bmad/components/cancel-confirm-modal/cancel-confirm-modal.component.scss
+++ b/src/app/features/auto-qa-bmad/components/cancel-confirm-modal/cancel-confirm-modal.component.scss
@@ -1,0 +1,14 @@
+.cancel-confirm-modal {
+  &__warning {
+    margin: 0 0 var(--aq-space-3);
+    font-size: var(--aq-font-size-sm);
+    color: var(--aq-text-secondary);
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--aq-space-2);
+    margin-top: var(--aq-space-4);
+  }
+}

--- a/src/app/features/auto-qa-bmad/components/cancel-confirm-modal/cancel-confirm-modal.component.spec.ts
+++ b/src/app/features/auto-qa-bmad/components/cancel-confirm-modal/cancel-confirm-modal.component.spec.ts
@@ -1,0 +1,83 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CancelConfirmModalComponent } from './cancel-confirm-modal.component';
+
+describe('CancelConfirmModalComponent', () => {
+  let fixture: ComponentFixture<CancelConfirmModalComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [CancelConfirmModalComponent] });
+    fixture = TestBed.createComponent(CancelConfirmModalComponent);
+  });
+
+  it('não renderiza o diálogo quando open é falso', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('renderiza o diálogo com campo de motivo opcional quando open é verdadeiro', () => {
+    fixture.componentRef.setInput('open', true);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('textarea')).not.toBeNull();
+  });
+
+  it('emite confirmed com o motivo digitado ao confirmar', () => {
+    fixture.componentRef.setInput('open', true);
+    fixture.detectChanges();
+
+    let emitted: string | undefined;
+    fixture.componentInstance.confirmed.subscribe((reason) => (emitted = reason));
+
+    const textarea: HTMLTextAreaElement = fixture.nativeElement.querySelector('textarea');
+    textarea.value = 'Cenário incorreto';
+    textarea.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('.cancel-confirm-modal__confirm button').click();
+
+    expect(emitted).toBe('Cenário incorreto');
+  });
+
+  it('emite confirmed com undefined quando nenhum motivo é informado', () => {
+    fixture.componentRef.setInput('open', true);
+    fixture.detectChanges();
+
+    let emitted: string | undefined = 'não deveria permanecer';
+    let called = false;
+    fixture.componentInstance.confirmed.subscribe((reason) => {
+      emitted = reason;
+      called = true;
+    });
+
+    fixture.nativeElement.querySelector('.cancel-confirm-modal__confirm button').click();
+
+    expect(called).toBeTrue();
+    expect(emitted).toBeUndefined();
+  });
+
+  it('emite dismissed ao clicar em voltar/fechar, sem emitir confirmed', () => {
+    fixture.componentRef.setInput('open', true);
+    fixture.detectChanges();
+
+    let confirmed = false;
+    let dismissed = false;
+    fixture.componentInstance.confirmed.subscribe(() => (confirmed = true));
+    fixture.componentInstance.dismissed.subscribe(() => (dismissed = true));
+
+    fixture.nativeElement.querySelector('.cancel-confirm-modal__dismiss button').click();
+
+    expect(dismissed).toBeTrue();
+    expect(confirmed).toBeFalse();
+  });
+
+  it('desabilita o botão de confirmação enquanto submitting é verdadeiro', () => {
+    fixture.componentRef.setInput('open', true);
+    fixture.componentRef.setInput('submitting', true);
+    fixture.detectChanges();
+
+    const confirmButton: HTMLButtonElement = fixture.nativeElement.querySelector(
+      '.cancel-confirm-modal__confirm button'
+    );
+    expect(confirmButton.disabled).toBeTrue();
+  });
+});

--- a/src/app/features/auto-qa-bmad/components/cancel-confirm-modal/cancel-confirm-modal.component.ts
+++ b/src/app/features/auto-qa-bmad/components/cancel-confirm-modal/cancel-confirm-modal.component.ts
@@ -1,0 +1,39 @@
+import { ChangeDetectionStrategy, Component, input, output, signal } from '@angular/core';
+import { AqbModalComponent } from '../../shared/ui/modal/aqb-modal.component';
+import { AqbTextareaComponent } from '../../shared/ui/textarea/aqb-textarea.component';
+import { AqbButtonComponent } from '../../shared/ui/button/aqb-button.component';
+
+/**
+ * Confirmação de uma ação destrutiva (cancelar). Não chama service — só
+ * emite o motivo (opcional) para quem hospeda decidir o que fazer.
+ */
+@Component({
+  selector: 'app-cancel-confirm-modal',
+  standalone: true,
+  imports: [AqbModalComponent, AqbTextareaComponent, AqbButtonComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './cancel-confirm-modal.component.html',
+  styleUrl: './cancel-confirm-modal.component.scss',
+})
+export class CancelConfirmModalComponent {
+  readonly open = input(false);
+  readonly submitting = input(false);
+
+  readonly confirmed = output<string | undefined>();
+  readonly dismissed = output<void>();
+
+  protected readonly reason = signal('');
+
+  onReasonChange(value: string): void {
+    this.reason.set(value);
+  }
+
+  onConfirm(): void {
+    const trimmed = this.reason().trim();
+    this.confirmed.emit(trimmed ? trimmed : undefined);
+  }
+
+  onDismiss(): void {
+    this.dismissed.emit();
+  }
+}

--- a/src/app/features/auto-qa-bmad/components/execution-approval-panel/execution-approval-panel.component.html
+++ b/src/app/features/auto-qa-bmad/components/execution-approval-panel/execution-approval-panel.component.html
@@ -1,0 +1,57 @@
+<aqb-panel title="Aprovar execução de comandos" class="execution-approval-panel">
+  <aqb-input
+    label="Aprovado por"
+    [value]="approvedBy()"
+    placeholder="Seu nome"
+    (valueChange)="onApprovedByChange($event)"
+  />
+
+  <fieldset class="execution-approval-panel__fieldset">
+    <legend>Comandos autorizados</legend>
+    @for (command of commands; track command) {
+      <label class="execution-approval-panel__checkbox">
+        <input
+          type="checkbox"
+          [value]="command"
+          (change)="toggleCommand(command, $any($event.target).checked)"
+        />
+        {{ command }}
+      </label>
+    }
+  </fieldset>
+
+  <label class="execution-approval-panel__checkbox">
+    <input
+      type="checkbox"
+      name="allowTestExecution"
+      (change)="allowTestExecution.set($any($event.target).checked)"
+    />
+    Permitir execução de testes
+  </label>
+
+  <label class="execution-approval-panel__checkbox">
+    <input
+      type="checkbox"
+      name="allowInstallCommand"
+      (change)="allowInstallCommand.set($any($event.target).checked)"
+    />
+    Permitir comando de instalação de dependências
+  </label>
+
+  <label class="execution-approval-panel__checkbox">
+    <input type="checkbox" name="allowBuildCommand" (change)="allowBuildCommand.set($any($event.target).checked)" />
+    Permitir comando de build
+  </label>
+
+  <span class="execution-approval-panel__submit">
+    <aqb-button
+      type="button"
+      variant="primary"
+      [loading]="submitting()"
+      [disabled]="!canSubmit() || submitting()"
+      (clicked)="onSubmit()"
+    >
+      Aprovar execução
+    </aqb-button>
+  </span>
+</aqb-panel>

--- a/src/app/features/auto-qa-bmad/components/execution-approval-panel/execution-approval-panel.component.scss
+++ b/src/app/features/auto-qa-bmad/components/execution-approval-panel/execution-approval-panel.component.scss
@@ -1,0 +1,30 @@
+.execution-approval-panel {
+  display: block;
+
+  &__fieldset {
+    border: none;
+    padding: 0;
+    margin: var(--aq-space-3) 0;
+
+    legend {
+      font-size: var(--aq-font-size-xs);
+      color: var(--aq-text-muted);
+      margin-bottom: var(--aq-space-1);
+    }
+  }
+
+  &__checkbox {
+    display: flex;
+    align-items: center;
+    gap: var(--aq-space-2);
+    font-family: var(--aq-font-family);
+    font-size: var(--aq-font-size-sm);
+    color: var(--aq-text-secondary);
+    margin-bottom: var(--aq-space-1);
+  }
+
+  &__submit {
+    display: inline-block;
+    margin-top: var(--aq-space-3);
+  }
+}

--- a/src/app/features/auto-qa-bmad/components/execution-approval-panel/execution-approval-panel.component.spec.ts
+++ b/src/app/features/auto-qa-bmad/components/execution-approval-panel/execution-approval-panel.component.spec.ts
@@ -1,0 +1,90 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ExecutionApprovalPanelComponent } from './execution-approval-panel.component';
+import { AutoQaExecutionApprovalRequest } from '../../models/auto-qa-execution.model';
+
+describe('ExecutionApprovalPanelComponent', () => {
+  let fixture: ComponentFixture<ExecutionApprovalPanelComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [ExecutionApprovalPanelComponent] });
+    fixture = TestBed.createComponent(ExecutionApprovalPanelComponent);
+    fixture.detectChanges();
+  });
+
+  function checkbox(value: string): HTMLInputElement {
+    return fixture.nativeElement.querySelector(`input[type="checkbox"][value="${value}"]`);
+  }
+
+  function namedCheckbox(name: string): HTMLInputElement {
+    return fixture.nativeElement.querySelector(`input[type="checkbox"][name="${name}"]`);
+  }
+
+  function approvedByField(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('.aqb-input__field');
+  }
+
+  function submitButton(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('.execution-approval-panel__submit button');
+  }
+
+  it('renderiza approvedBy e os 11 comandos autorizáveis (ExecutionCommandId)', () => {
+    expect(approvedByField()).not.toBeNull();
+    const commands = [
+      'NPM_TEST',
+      'NPM_TEST_E2E',
+      'PLAYWRIGHT_TEST',
+      'CYPRESS_RUN',
+      'CYPRESS_SCRIPT_RUN',
+      'GRADLE_WRAPPER_TEST',
+      'GRADLE_WRAPPER_CLEAN_TEST',
+      'MAVEN_WRAPPER_TEST',
+      'MAVEN_TEST',
+      'ROBOT_TEST',
+      'PYTEST',
+    ];
+    for (const command of commands) {
+      expect(checkbox(command)).withContext(command).not.toBeNull();
+    }
+  });
+
+  it('desabilita o envio quando approvedBy está vazio ou nenhum comando foi selecionado', () => {
+    expect(submitButton().disabled).toBeTrue();
+
+    approvedByField().value = 'jean';
+    approvedByField().dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(submitButton().disabled).toBeTrue();
+  });
+
+  it('emite approved com o payload correto quando válido', () => {
+    approvedByField().value = '  jean  ';
+    approvedByField().dispatchEvent(new Event('input'));
+
+    checkbox('NPM_TEST').checked = true;
+    checkbox('NPM_TEST').dispatchEvent(new Event('change'));
+
+    namedCheckbox('allowTestExecution').checked = true;
+    namedCheckbox('allowTestExecution').dispatchEvent(new Event('change'));
+
+    fixture.detectChanges();
+
+    let emitted: AutoQaExecutionApprovalRequest | undefined;
+    fixture.componentInstance.approved.subscribe((v) => (emitted = v));
+
+    submitButton().click();
+
+    expect(emitted).toEqual({
+      approvedBy: 'jean',
+      allowedCommands: ['NPM_TEST'],
+      allowTestExecution: true,
+      allowInstallCommand: false,
+      allowBuildCommand: false,
+    });
+  });
+
+  it('desabilita o envio enquanto submitting é verdadeiro', () => {
+    fixture.componentRef.setInput('submitting', true);
+    fixture.detectChanges();
+    expect(submitButton().disabled).toBeTrue();
+  });
+});

--- a/src/app/features/auto-qa-bmad/components/execution-approval-panel/execution-approval-panel.component.ts
+++ b/src/app/features/auto-qa-bmad/components/execution-approval-panel/execution-approval-panel.component.ts
@@ -1,0 +1,77 @@
+import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
+import { AqbPanelComponent } from '../../shared/ui/panel/aqb-panel.component';
+import { AqbInputComponent } from '../../shared/ui/input/aqb-input.component';
+import { AqbButtonComponent } from '../../shared/ui/button/aqb-button.component';
+import { AutoQaExecutionApprovalRequest, ExecutionCommandId } from '../../models/auto-qa-execution.model';
+
+const COMMANDS: ExecutionCommandId[] = [
+  'NPM_TEST',
+  'NPM_TEST_E2E',
+  'PLAYWRIGHT_TEST',
+  'CYPRESS_RUN',
+  'CYPRESS_SCRIPT_RUN',
+  'GRADLE_WRAPPER_TEST',
+  'GRADLE_WRAPPER_CLEAN_TEST',
+  'MAVEN_WRAPPER_TEST',
+  'MAVEN_TEST',
+  'ROBOT_TEST',
+  'PYTEST',
+];
+
+/**
+ * Aprovação de execução de comandos. Os comandos oferecidos são o
+ * vocabulário estático real de ExecutionCommandId (backend) — a curadoria
+ * de qual autorizar é do usuário, o painel não infere quais comandos
+ * valem para esta execução (o DTO não traz essa informação).
+ */
+@Component({
+  selector: 'app-execution-approval-panel',
+  standalone: true,
+  imports: [AqbPanelComponent, AqbInputComponent, AqbButtonComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './execution-approval-panel.component.html',
+  styleUrl: './execution-approval-panel.component.scss',
+})
+export class ExecutionApprovalPanelComponent {
+  readonly submitting = input(false);
+  readonly approved = output<AutoQaExecutionApprovalRequest>();
+
+  protected readonly commands = COMMANDS;
+
+  protected readonly approvedBy = signal('');
+  protected readonly selectedCommands = signal<ReadonlySet<ExecutionCommandId>>(new Set());
+  protected readonly allowTestExecution = signal(false);
+  protected readonly allowInstallCommand = signal(false);
+  protected readonly allowBuildCommand = signal(false);
+
+  protected readonly canSubmit = computed(
+    () => this.approvedBy().trim().length > 0 && this.selectedCommands().size > 0
+  );
+
+  onApprovedByChange(value: string): void {
+    this.approvedBy.set(value);
+  }
+
+  toggleCommand(command: ExecutionCommandId, checked: boolean): void {
+    const next = new Set(this.selectedCommands());
+    if (checked) {
+      next.add(command);
+    } else {
+      next.delete(command);
+    }
+    this.selectedCommands.set(next);
+  }
+
+  onSubmit(): void {
+    if (!this.canSubmit() || this.submitting()) {
+      return;
+    }
+    this.approved.emit({
+      approvedBy: this.approvedBy().trim(),
+      allowedCommands: Array.from(this.selectedCommands()),
+      allowTestExecution: this.allowTestExecution(),
+      allowInstallCommand: this.allowInstallCommand(),
+      allowBuildCommand: this.allowBuildCommand(),
+    });
+  }
+}

--- a/src/app/features/auto-qa-bmad/pages/execution-detail-page/execution-detail-page.component.html
+++ b/src/app/features/auto-qa-bmad/pages/execution-detail-page/execution-detail-page.component.html
@@ -5,6 +5,10 @@
     <p class="execution-detail-page__error" role="alert">{{ state.error() }}</p>
   }
 
+  @if (state.actionError()) {
+    <p class="execution-detail-page__error" role="alert">{{ state.actionError() }}</p>
+  }
+
   @if (state.loading() && !state.current()) {
     <aqb-loading label="Carregando execução..." />
   }
@@ -47,7 +51,29 @@
 
       <app-error-list [errors]="state.currentErrors()" />
 
-      <app-action-bar [availableActions]="state.currentAvailableActions()" [pendingAction]="null" />
+      <app-action-bar
+        [availableActions]="state.currentAvailableActions()"
+        [pendingAction]="state.pendingAction()"
+        (actionTriggered)="onActionTriggered($event)"
+      />
+
+      @if (showApplyApprovalPanel()) {
+        <app-apply-approval-panel [submitting]="state.pendingAction() === 'APPROVE_FILE_UPDATE'" (approved)="onApplyApproved($event)" />
+      }
+
+      @if (showExecutionApprovalPanel()) {
+        <app-execution-approval-panel
+          [submitting]="state.pendingAction() === 'APPROVE_EXECUTION'"
+          (approved)="onExecutionApproved($event)"
+        />
+      }
     </div>
+
+    <app-cancel-confirm-modal
+      [open]="showCancelModal()"
+      [submitting]="state.pendingAction() === 'CANCEL'"
+      (confirmed)="onCancelConfirmed($event)"
+      (dismissed)="onCancelDismissed()"
+    />
   }
 </div>

--- a/src/app/features/auto-qa-bmad/pages/execution-detail-page/execution-detail-page.component.spec.ts
+++ b/src/app/features/auto-qa-bmad/pages/execution-detail-page/execution-detail-page.component.spec.ts
@@ -13,19 +13,35 @@ describe('ExecutionDetailPageComponent', () => {
   const loadingSignal = signal(false);
   const errorSignal = signal<string | null>(null);
   const selectedExecutionIdSignal = signal<string | null>(null);
+  const pendingActionSignal = signal<string | null>(null);
+  const actionErrorSignal = signal<string | null>(null);
   const loadExecutionSpy = jasmine.createSpy('loadExecution');
+  const startSpy = jasmine.createSpy('start');
+  const continueExecutionSpy = jasmine.createSpy('continueExecution');
+  const generateSpy = jasmine.createSpy('generate');
+  const cancelSpy = jasmine.createSpy('cancel');
+  const approveFileUpdateSpy = jasmine.createSpy('approveFileUpdate');
+  const approveExecutionSpy = jasmine.createSpy('approveExecution');
 
   const fakeState = {
     current: currentSignal,
     loading: loadingSignal,
     error: errorSignal,
     selectedExecutionId: selectedExecutionIdSignal,
+    pendingAction: pendingActionSignal,
+    actionError: actionErrorSignal,
     loadExecution: loadExecutionSpy,
     hasCurrentExecution: () => currentSignal() !== null,
     canRefresh: () => currentSignal() !== null && !loadingSignal(),
     currentWarnings: () => currentSignal()?.warnings ?? [],
     currentErrors: () => currentSignal()?.errors ?? [],
     currentAvailableActions: () => currentSignal()?.availableActions ?? [],
+    start: startSpy,
+    continueExecution: continueExecutionSpy,
+    generate: generateSpy,
+    cancel: cancelSpy,
+    approveFileUpdate: approveFileUpdateSpy,
+    approveExecution: approveExecutionSpy,
   };
 
   const execution = (overrides: Partial<AutoQaExecutionResponse> = {}): AutoQaExecutionResponse => ({
@@ -54,7 +70,21 @@ describe('ExecutionDetailPageComponent', () => {
     loadingSignal.set(false);
     errorSignal.set(null);
     selectedExecutionIdSignal.set(null);
+    pendingActionSignal.set(null);
+    actionErrorSignal.set(null);
     loadExecutionSpy.calls.reset();
+    startSpy.calls.reset();
+    continueExecutionSpy.calls.reset();
+    generateSpy.calls.reset();
+    cancelSpy.calls.reset();
+    approveFileUpdateSpy.calls.reset();
+    approveExecutionSpy.calls.reset();
+    startSpy.and.returnValue(of(execution()));
+    continueExecutionSpy.and.returnValue(of(execution()));
+    generateSpy.and.returnValue(of(execution()));
+    cancelSpy.and.returnValue(of(execution({ status: 'CANCELLED' })));
+    approveFileUpdateSpy.and.returnValue(of(execution()));
+    approveExecutionSpy.and.returnValue(of(execution()));
 
     TestBed.configureTestingModule({
       imports: [ExecutionDetailPageComponent],
@@ -152,6 +182,128 @@ describe('ExecutionDetailPageComponent', () => {
       fixture.detectChanges();
       const refresh: HTMLButtonElement = fixture.nativeElement.querySelector('.execution-detail-page__refresh button');
       expect(refresh.disabled).toBeTrue();
+    });
+
+    describe('ações do workflow', () => {
+      function triggerAction(action: string): void {
+        const actionBar = fixture.debugElement.query((n) => n.name === 'app-action-bar');
+        actionBar.triggerEventHandler('actionTriggered', action);
+      }
+
+      it('START despacha state.start diretamente, sem modal/painel', () => {
+        fixture.detectChanges();
+        triggerAction('START');
+        expect(startSpy).toHaveBeenCalledWith('exec-1');
+      });
+
+      it('CONTINUE despacha state.continueExecution diretamente', () => {
+        fixture.detectChanges();
+        triggerAction('CONTINUE');
+        expect(continueExecutionSpy).toHaveBeenCalledWith('exec-1');
+      });
+
+      it('GENERATE despacha state.generate diretamente', () => {
+        fixture.detectChanges();
+        triggerAction('GENERATE');
+        expect(generateSpy).toHaveBeenCalledWith('exec-1');
+      });
+
+      it('CANCEL abre o modal de confirmação sem chamar state.cancel imediatamente', () => {
+        fixture.detectChanges();
+        triggerAction('CANCEL');
+        fixture.detectChanges();
+
+        expect(cancelSpy).not.toHaveBeenCalled();
+        expect(fixture.nativeElement.querySelector('app-cancel-confirm-modal [role="dialog"]')).not.toBeNull();
+      });
+
+      it('confirmar o cancelamento chama state.cancel com o motivo informado', () => {
+        fixture.detectChanges();
+        triggerAction('CANCEL');
+        fixture.detectChanges();
+
+        const modal = fixture.debugElement.query((n) => n.name === 'app-cancel-confirm-modal');
+        modal.triggerEventHandler('confirmed', 'Motivo de teste');
+
+        expect(cancelSpy).toHaveBeenCalledWith('exec-1', 'Motivo de teste');
+      });
+
+      it('dispensar o modal de cancelamento não chama state.cancel', () => {
+        fixture.detectChanges();
+        triggerAction('CANCEL');
+        fixture.detectChanges();
+
+        const modal = fixture.debugElement.query((n) => n.name === 'app-cancel-confirm-modal');
+        modal.triggerEventHandler('dismissed', undefined);
+        fixture.detectChanges();
+
+        expect(cancelSpy).not.toHaveBeenCalled();
+        expect(fixture.nativeElement.querySelector('app-cancel-confirm-modal [role="dialog"]')).toBeNull();
+      });
+
+      it('APPROVE_FILE_UPDATE mostra o painel de aprovação de aplicação', () => {
+        fixture.detectChanges();
+        triggerAction('APPROVE_FILE_UPDATE');
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('app-apply-approval-panel')).not.toBeNull();
+      });
+
+      it('aprovar a aplicação chama state.approveFileUpdate com o request emitido pelo painel', () => {
+        fixture.detectChanges();
+        triggerAction('APPROVE_FILE_UPDATE');
+        fixture.detectChanges();
+
+        const panel = fixture.debugElement.query((n) => n.name === 'app-apply-approval-panel');
+        const request = {
+          approvedBy: 'jean',
+          authorizedOperations: ['CREATE'],
+          allowFileUpdate: true,
+          allowWarnings: false,
+        };
+        panel.triggerEventHandler('approved', request);
+
+        expect(approveFileUpdateSpy).toHaveBeenCalledWith('exec-1', request);
+      });
+
+      it('APPROVE_EXECUTION mostra o painel de aprovação de execução', () => {
+        fixture.detectChanges();
+        triggerAction('APPROVE_EXECUTION');
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('app-execution-approval-panel')).not.toBeNull();
+      });
+
+      it('aprovar a execução chama state.approveExecution com o request emitido pelo painel', () => {
+        fixture.detectChanges();
+        triggerAction('APPROVE_EXECUTION');
+        fixture.detectChanges();
+
+        const panel = fixture.debugElement.query((n) => n.name === 'app-execution-approval-panel');
+        const request = {
+          approvedBy: 'jean',
+          allowedCommands: ['NPM_TEST'],
+          allowTestExecution: true,
+          allowInstallCommand: false,
+          allowBuildCommand: false,
+        };
+        panel.triggerEventHandler('approved', request);
+
+        expect(approveExecutionSpy).toHaveBeenCalledWith('exec-1', request);
+      });
+
+      it('mostra actionError() em role="alert"', () => {
+        actionErrorSignal.set('Esta ação não está disponível no momento.');
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toContain('Esta ação não está disponível no momento.');
+      });
+
+      it('repassa pendingAction() para a ActionBar', () => {
+        pendingActionSignal.set('START');
+        fixture.detectChanges();
+        const actionBar = fixture.debugElement.query((n) => n.name === 'app-action-bar');
+        expect(actionBar.componentInstance.pendingAction()).toBe('START');
+      });
     });
   });
 

--- a/src/app/features/auto-qa-bmad/pages/execution-detail-page/execution-detail-page.component.ts
+++ b/src/app/features/auto-qa-bmad/pages/execution-detail-page/execution-detail-page.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Observable } from 'rxjs';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { AutoQaExecutionStateService } from '../../state/auto-qa-execution-state.service';
 import { AqbPageHeaderComponent } from '../../shared/ui/page-header/aqb-page-header.component';
@@ -13,15 +14,26 @@ import { ExecutionSummaryComponent } from '../../components/execution-summary/ex
 import { WarningListComponent } from '../../components/warning-list/warning-list.component';
 import { ErrorListComponent } from '../../components/error-list/error-list.component';
 import { ActionBarComponent } from '../../components/action-bar/action-bar.component';
+import { CancelConfirmModalComponent } from '../../components/cancel-confirm-modal/cancel-confirm-modal.component';
+import { ApplyApprovalPanelComponent } from '../../components/apply-approval-panel/apply-approval-panel.component';
+import { ExecutionApprovalPanelComponent } from '../../components/execution-approval-panel/execution-approval-panel.component';
 import { AUTO_QA_STAGE_CATALOG, AutoQaStageId, getStageMetadata } from '../../models/auto-qa-stage-catalog';
 import { resolveStageVisualState } from '../../shared/utils/resolve-stage-visual-state';
+import { AutoQaAvailableAction } from '../../models/auto-qa-enums.model';
+import {
+  AutoQaApplyApprovalRequest,
+  AutoQaExecutionApprovalRequest,
+  AutoQaExecutionResponse,
+} from '../../models/auto-qa-execution.model';
 
 /**
- * Página smart de detalhe de uma execução. Nesta fase (12.3.3) adiciona a
- * Timeline interativa e o painel de detalhe por etapa. `selectedStage` é
- * estado exclusivamente de UI (não vai para o AutoQaExecutionStateService):
- * nunca chama API, nunca altera o backend, só decide o que o painel
- * mostra.
+ * Página smart de detalhe de uma execução. A partir da Fase 12.3.4, ações
+ * funcionais (START/CONTINUE/GENERATE/CANCEL/APPROVE_FILE_UPDATE/
+ * APPROVE_EXECUTION) são despachadas por aqui — a ActionBar só emite a
+ * intenção, quem decide abrir modal/painel ou disparar direto é esta
+ * página. `selectedStage`/`showCancelModal`/`showApplyApprovalPanel`/
+ * `showExecutionApprovalPanel` são estado exclusivamente de UI (não vão
+ * para o AutoQaExecutionStateService).
  */
 @Component({
   selector: 'app-execution-detail-page',
@@ -39,6 +51,9 @@ import { resolveStageVisualState } from '../../shared/utils/resolve-stage-visual
     WarningListComponent,
     ErrorListComponent,
     ActionBarComponent,
+    CancelConfirmModalComponent,
+    ApplyApprovalPanelComponent,
+    ExecutionApprovalPanelComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './execution-detail-page.component.html',
@@ -50,6 +65,9 @@ export class ExecutionDetailPageComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
 
   private readonly _selectedStage = signal<AutoQaStageId | null>(null);
+  protected readonly showCancelModal = signal(false);
+  protected readonly showApplyApprovalPanel = signal(false);
+  protected readonly showExecutionApprovalPanel = signal(false);
 
   /** Seleção efetiva: escolha explícita do usuário, com fallback currentStage → lastStageCompleted → primeira etapa do catálogo. */
   protected readonly selectedStage = computed<AutoQaStageId>(() => {
@@ -84,5 +102,75 @@ export class ExecutionDetailPageComponent implements OnInit {
     if (executionId) {
       this.state.loadExecution(executionId);
     }
+  }
+
+  onActionTriggered(action: AutoQaAvailableAction): void {
+    const executionId = this.state.selectedExecutionId();
+    if (!executionId) {
+      return;
+    }
+    switch (action) {
+      case 'START':
+        this.dispatch(this.state.start(executionId));
+        break;
+      case 'CONTINUE':
+        this.dispatch(this.state.continueExecution(executionId));
+        break;
+      case 'GENERATE':
+        this.dispatch(this.state.generate(executionId));
+        break;
+      case 'CANCEL':
+        this.showCancelModal.set(true);
+        break;
+      case 'APPROVE_FILE_UPDATE':
+        this.showApplyApprovalPanel.set(true);
+        break;
+      case 'APPROVE_EXECUTION':
+        this.showExecutionApprovalPanel.set(true);
+        break;
+      default:
+        // Ação ainda não suportada — a ActionBar já a mantém desabilitada,
+        // não deveria emitir actionTriggered para ela.
+        break;
+    }
+  }
+
+  onCancelConfirmed(reason: string | undefined): void {
+    const executionId = this.state.selectedExecutionId();
+    if (!executionId) {
+      return;
+    }
+    this.showCancelModal.set(false);
+    this.dispatch(this.state.cancel(executionId, reason));
+  }
+
+  onCancelDismissed(): void {
+    this.showCancelModal.set(false);
+  }
+
+  onApplyApproved(request: AutoQaApplyApprovalRequest): void {
+    const executionId = this.state.selectedExecutionId();
+    if (!executionId) {
+      return;
+    }
+    this.showApplyApprovalPanel.set(false);
+    this.dispatch(this.state.approveFileUpdate(executionId, request));
+  }
+
+  onExecutionApproved(request: AutoQaExecutionApprovalRequest): void {
+    const executionId = this.state.selectedExecutionId();
+    if (!executionId) {
+      return;
+    }
+    this.showExecutionApprovalPanel.set(false);
+    this.dispatch(this.state.approveExecution(executionId, request));
+  }
+
+  private dispatch(action$: Observable<AutoQaExecutionResponse>): void {
+    action$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      error: () => {
+        // erro já refletido em state.actionError(); nada mais a fazer aqui.
+      },
+    });
   }
 }

--- a/src/app/features/auto-qa-bmad/state/auto-qa-execution-state.service.spec.ts
+++ b/src/app/features/auto-qa-bmad/state/auto-qa-execution-state.service.spec.ts
@@ -33,14 +33,24 @@ describe('AutoQaExecutionStateService', () => {
   const networkError = () => new HttpErrorResponse({ status: 0 });
 
   beforeEach(() => {
-    serviceSpy = jasmine.createSpyObj('AutoQaExecutionService', ['list', 'get', 'create']);
+    serviceSpy = jasmine.createSpyObj('AutoQaExecutionService', [
+      'list',
+      'get',
+      'create',
+      'start',
+      'continueExecution',
+      'generate',
+      'cancel',
+      'registerApplyApproval',
+      'registerExecutionApproval',
+    ]);
     TestBed.configureTestingModule({
       providers: [AutoQaExecutionStateService, { provide: AutoQaExecutionService, useValue: serviceSpy }],
     });
     state = TestBed.inject(AutoQaExecutionStateService);
   });
 
-  it('estado inicial: sem execução, lista vazia, sem erro, sem loading/creating, paginação zerada, sem seleção', () => {
+  it('estado inicial: sem execução, lista vazia, sem erro, sem loading/creating, paginação zerada, sem seleção, sem pendingAction/actionError', () => {
     expect(state.current()).toBeNull();
     expect(state.list()).toEqual([]);
     expect(state.error()).toBeNull();
@@ -48,6 +58,8 @@ describe('AutoQaExecutionStateService', () => {
     expect(state.creating()).toBeFalse();
     expect(state.pagination()).toEqual({ page: 0, size: 20, totalElements: 0 });
     expect(state.selectedExecutionId()).toBeNull();
+    expect(state.pendingAction()).toBeNull();
+    expect(state.actionError()).toBeNull();
   });
 
   describe('loadList', () => {
@@ -237,6 +249,89 @@ describe('AutoQaExecutionStateService', () => {
         return of(execution());
       });
       state.loadExecution('exec-1');
+    });
+  });
+
+  describe('ações de workflow (start/continue/generate/cancel/aprovações)', () => {
+    it('start(): chama o service, ativa pendingAction("START") durante a chamada e atualiza current() com a resposta', () => {
+      const updated = execution({ status: 'RUNNING', currentStage: 'DISCOVERY' });
+      let pendingDuringCall: string | null | undefined;
+      serviceSpy.start.and.callFake(() => {
+        pendingDuringCall = state.pendingAction();
+        return of(updated);
+      });
+
+      state.start('exec-1').subscribe();
+
+      expect(serviceSpy.start).toHaveBeenCalledWith('exec-1');
+      expect(pendingDuringCall).toBe('START');
+      expect(state.pendingAction()).toBeNull();
+      expect(state.current()).toEqual(updated);
+    });
+
+    it('continueExecution(): chama executionService.continueExecution', () => {
+      serviceSpy.continueExecution.and.returnValue(of(execution()));
+      state.continueExecution('exec-1').subscribe();
+      expect(serviceSpy.continueExecution).toHaveBeenCalledWith('exec-1');
+    });
+
+    it('generate(): chama executionService.generate', () => {
+      serviceSpy.generate.and.returnValue(of(execution()));
+      state.generate('exec-1').subscribe();
+      expect(serviceSpy.generate).toHaveBeenCalledWith('exec-1');
+    });
+
+    it('cancel(): chama executionService.cancel com o motivo informado', () => {
+      serviceSpy.cancel.and.returnValue(of(execution({ status: 'CANCELLED' })));
+      state.cancel('exec-1', 'Cancelado pelo usuário').subscribe();
+      expect(serviceSpy.cancel).toHaveBeenCalledWith('exec-1', 'Cancelado pelo usuário');
+    });
+
+    it('approveFileUpdate(): chama executionService.registerApplyApproval com o request', () => {
+      const request = {
+        approvedBy: 'jean',
+        authorizedOperations: ['CREATE' as const],
+        allowFileUpdate: true,
+        allowWarnings: false,
+      };
+      serviceSpy.registerApplyApproval.and.returnValue(of(execution()));
+      state.approveFileUpdate('exec-1', request).subscribe();
+      expect(serviceSpy.registerApplyApproval).toHaveBeenCalledWith('exec-1', request);
+    });
+
+    it('approveExecution(): chama executionService.registerExecutionApproval com o request', () => {
+      const request = {
+        approvedBy: 'jean',
+        allowedCommands: ['NPM_TEST' as const],
+        allowTestExecution: true,
+        allowInstallCommand: false,
+        allowBuildCommand: false,
+      };
+      serviceSpy.registerExecutionApproval.and.returnValue(of(execution()));
+      state.approveExecution('exec-1', request).subscribe();
+      expect(serviceSpy.registerExecutionApproval).toHaveBeenCalledWith('exec-1', request);
+    });
+
+    it('em erro, define actionError(), limpa pendingAction() e propaga o erro para quem assinou', () => {
+      serviceSpy.start.and.returnValue(throwError(() => networkError()));
+
+      let receivedError = false;
+      state.start('exec-1').subscribe({ error: () => (receivedError = true) });
+
+      expect(receivedError).toBeTrue();
+      expect(state.pendingAction()).toBeNull();
+      expect(state.actionError()).toBeTruthy();
+    });
+
+    it('ignora uma nova ação enquanto outra ainda está em andamento (guard entre ações diferentes)', () => {
+      serviceSpy.start.and.callFake(() => {
+        state.generate('exec-1').subscribe(); // reentrante, deve ser ignorado
+        return of(execution());
+      });
+
+      state.start('exec-1').subscribe();
+
+      expect(serviceSpy.generate).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/features/auto-qa-bmad/state/auto-qa-execution-state.service.ts
+++ b/src/app/features/auto-qa-bmad/state/auto-qa-execution-state.service.ts
@@ -2,7 +2,12 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable, computed, inject, signal } from '@angular/core';
 import { EMPTY, Observable, finalize, tap } from 'rxjs';
 import { AutoQaExecutionService } from '../services/auto-qa-execution.service';
-import { AutoQaExecutionResponse } from '../models/auto-qa-execution.model';
+import {
+  AutoQaApplyApprovalRequest,
+  AutoQaExecutionApprovalRequest,
+  AutoQaExecutionResponse,
+} from '../models/auto-qa-execution.model';
+import { AutoQaAvailableAction } from '../models/auto-qa-enums.model';
 import { mapHttpErrorToUiError } from '../shared/utils/auto-qa-error-mapper';
 
 export interface AutoQaPagination {
@@ -30,6 +35,8 @@ export class AutoQaExecutionStateService {
   private readonly _error = signal<string | null>(null);
   private readonly _pagination = signal<AutoQaPagination>({ page: 0, size: 20, totalElements: 0 });
   private readonly _selectedExecutionId = signal<string | null>(null);
+  private readonly _pendingAction = signal<AutoQaAvailableAction | null>(null);
+  private readonly _actionError = signal<string | null>(null);
 
   readonly current = this._current.asReadonly();
   readonly list = this._list.asReadonly();
@@ -38,6 +45,8 @@ export class AutoQaExecutionStateService {
   readonly error = this._error.asReadonly();
   readonly pagination = this._pagination.asReadonly();
   readonly selectedExecutionId = this._selectedExecutionId.asReadonly();
+  readonly pendingAction = this._pendingAction.asReadonly();
+  readonly actionError = this._actionError.asReadonly();
 
   readonly hasExecutions = computed(() => this._list().length > 0);
   readonly hasCurrentExecution = computed(() => this._current() !== null);
@@ -103,6 +112,57 @@ export class AutoQaExecutionStateService {
         error: (err: HttpErrorResponse) => this._error.set(mapHttpErrorToUiError(err).message),
       }),
       finalize(() => this._creating.set(false))
+    );
+  }
+
+  start(executionId: string): Observable<AutoQaExecutionResponse> {
+    return this.dispatch('START', () => this.executionService.start(executionId));
+  }
+
+  continueExecution(executionId: string): Observable<AutoQaExecutionResponse> {
+    return this.dispatch('CONTINUE', () => this.executionService.continueExecution(executionId));
+  }
+
+  generate(executionId: string): Observable<AutoQaExecutionResponse> {
+    return this.dispatch('GENERATE', () => this.executionService.generate(executionId));
+  }
+
+  cancel(executionId: string, reason?: string): Observable<AutoQaExecutionResponse> {
+    return this.dispatch('CANCEL', () => this.executionService.cancel(executionId, reason));
+  }
+
+  approveFileUpdate(executionId: string, request: AutoQaApplyApprovalRequest): Observable<AutoQaExecutionResponse> {
+    return this.dispatch('APPROVE_FILE_UPDATE', () => this.executionService.registerApplyApproval(executionId, request));
+  }
+
+  approveExecution(
+    executionId: string,
+    request: AutoQaExecutionApprovalRequest
+  ): Observable<AutoQaExecutionResponse> {
+    return this.dispatch('APPROVE_EXECUTION', () => this.executionService.registerExecutionApproval(executionId, request));
+  }
+
+  /**
+   * Ponto único de despacho de ações do workflow. Ignora uma nova ação
+   * enquanto outra ainda está em andamento (guard entre ações diferentes,
+   * não só dentro da mesma). Sempre atualiza current() com a resposta
+   * autoritativa do backend — nunca recalcula status/availableActions.
+   */
+  private dispatch(
+    action: AutoQaAvailableAction,
+    call: () => Observable<AutoQaExecutionResponse>
+  ): Observable<AutoQaExecutionResponse> {
+    if (this._pendingAction()) {
+      return EMPTY;
+    }
+    this._pendingAction.set(action);
+    this._actionError.set(null);
+    return call().pipe(
+      tap((response) => this._current.set(response)),
+      tap({
+        error: (err: HttpErrorResponse) => this._actionError.set(mapHttpErrorToUiError(err).message),
+      }),
+      finalize(() => this._pendingAction.set(null))
     );
   }
 }


### PR DESCRIPTION
Adiciona despacho real de START/CONTINUE/GENERATE/CANCEL/APPROVE_FILE_UPDATE/ APPROVE_EXECUTION via AutoQaExecutionStateService (pendingAction/actionError únicos, guard contra ação concorrente), ActionBar funcional para essas ações, modal de confirmação de cancelamento e painéis de aprovação de aplicação e execução. APPLY/EXECUTE reais permanecem fora de escopo.